### PR TITLE
Potential fix for code scanning alert no. 3: Incomplete URL substring sanitization

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -59,8 +59,19 @@ document.addEventListener("DOMContentLoaded", async () => {
   function notifyContentScript(message) {
     chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
       const tab = tabs[0];
-      if (tab?.id && tab.url?.includes("kick.com")) {
-        chrome.tabs.sendMessage(tab.id, message);
+      if (tab?.id && tab.url) {
+        try {
+          const allowedHosts = [
+            "kick.com",
+            "www.kick.com"
+          ];
+          const tabHost = new URL(tab.url).hostname;
+          if (allowedHosts.includes(tabHost)) {
+            chrome.tabs.sendMessage(tab.id, message);
+          }
+        } catch (e) {
+          // Invalid URL, do nothing
+        }
       }
     });
   }


### PR DESCRIPTION
Potential fix for [https://github.com/berkaygediz/uKick/security/code-scanning/3](https://github.com/berkaygediz/uKick/security/code-scanning/3)

To securely check if a URL is associated with `kick.com`, parse the URL and explicitly inspect the `hostname` property. Then, check whether the parsed hostname is equal to `"kick.com"` or to an allowed subdomain such as `"www.kick.com"` as appropriate. This eliminates the possibility of substring-related bypasses, as only the actual domain and permitted subdomains will match. You should replace the use of `.includes("kick.com")` with a whitelist that strictly matches the hostname. 

Edit only the relevant portion in `popup.js`, specifically in the `notifyContentScript` function, to:  
- Parse the `tab.url` into a URL object.  
- Check if the parsed hostname is exactly equal to (or in a whitelist of) allowed hostnames.  
- Use this check in place of `.includes("kick.com")`.  
You may use the built-in `URL` constructor in JavaScript and do not need to add any dependencies for this fix.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
