### PR TITLE
Potential fix for code scanning alert no. 15: Incomplete URL substring sanitization

### DIFF
--- a/firefox/content.js
+++ b/firefox/content.js
@@ -1139,7 +1139,8 @@
         try {
             const key = "search-history";
 
-            if (!location.hostname.includes("kick.com")) return;
+            const hostname = location.hostname;
+            if (!(hostname === "kick.com" || hostname.endsWith(".kick.com"))) return;
 
             const current = localStorage.getItem(key);
 


### PR DESCRIPTION
Potential fix for [https://github.com/berkaygediz/uKick/security/code-scanning/15](https://github.com/berkaygediz/uKick/security/code-scanning/15)

In general, to fix incomplete URL substring sanitization, you should avoid substring checks on hostnames and instead compare the parsed host against an explicit, exact allowlist (or otherwise validate it structurally). Here, we don’t even need to parse a URL, because we are already using `location.hostname`, which is a parsed host string. The goal is simply to ensure that the function only runs on `kick.com` and its intended subdomain(s), without relying on `includes`.

The best fix with minimal behavior change is to replace `location.hostname.includes("kick.com")` with an explicit equality/endsWith check that correctly handles the expected hostnames while rejecting attackers’ lookalike hosts. For example, checking `hostname === "kick.com"` or `hostname.endsWith(".kick.com")` (to allow subdomains) is robust: `evilkick.com` fails, and `kick.com.evil.com` fails, but `www.kick.com` passes. Since the userscript metadata already restricts execution to `kick.com` and `www.kick.com`, this will not change behavior in normal use but will satisfy the security rule.

Concretely, in `firefox/content.js`, inside `clearSearchHistory`, change the `if (!location.hostname.includes("kick.com")) return;` line to a whitelist check on `location.hostname`, such as:

```js
const hostname = location.hostname;
if (!(hostname === "kick.com" || hostname.endsWith(".kick.com"))) return;
```

This requires no new imports or helper methods and stays entirely within the shown snippet.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
